### PR TITLE
ci: only use latest for the GHA runners

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         node-version: [10.x, 12.x, 13.x, 14.x, 15.x]
-        os: [ubuntu-latest, windows-latest, macos-latest, windows-2019, ubuntu-20.04, ubuntu-18.04, ubuntu-16.04, macos-10.15]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1


### PR DESCRIPTION
It looks like the cron set in the GitHub Action workflow has been failing for ~7 months which correlates nicely with the deprecation of the Ubuntu 20.04 LTS runner as noted in [the last successful run](https://github.com/marvinschopf/swot-node/actions/runs/14457558789).

> The Ubuntu-20.04 brownout takes place from 2025-02-01. For more details, see https://github.com/actions/runner-images/issues/11101

This PR just moves it to `latest` only. Is that a good idea? ¯\_(ツ)_/¯ as with anything it's a trade off. Will it work though? Probably.

Anyway, I think a lot of folks a finding value from this package as per the weekly downloads noted in NPM (~5k as per the time of writing). So, I hope we can get it going again!
